### PR TITLE
Fixes #9 Circle Perimeter Fixed

### DIFF
--- a/Calculator.java
+++ b/Calculator.java
@@ -120,7 +120,7 @@ public class Calculator {
 	 * @return the perimeter of a circle with radius r.
 	 */
 	public double cirPer(double r) {
-		return Math.PI * r * r;
+		return Math.PI * r * 2;
 	}
 
 	/**


### PR DESCRIPTION
The formula for circle perimeter should be PI*r*2 instead of PI*r*r